### PR TITLE
Dynamic firmware download

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import AppNavigator from './src/navigation/AppNavigator';
 import { Provider } from 'react-redux';
 import store, { persistor } from './src/redux/store';
@@ -6,9 +6,15 @@ import { PersistGate } from 'redux-persist/integration/react';
 import { ActivityIndicator } from 'react-native';
 import { ThemeProvider } from './src/context/ThemeContext';
 import { LogBox, StatusBar } from 'react-native';
+import {downloadLatestFirmware} from './src/utils/firmwareManager';
 LogBox.ignoreAllLogs();
 
 const App = () => {
+  useEffect(() => {
+    downloadLatestFirmware().catch(err =>
+      console.error('Failed to download firmware:', err),
+    );
+  }, []);
   return (
     <Provider store={store}>
       <PersistGate loading={<ActivityIndicator />} persistor={persistor}>

--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = 'test-file-stub';

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,7 @@
 module.exports = {
   preset: 'react-native',
+  moduleNameMapper: {
+    '\\.(png|jpg|jpeg|svg)$': '<rootDir>/__mocks__/fileMock.js',
+  },
+  setupFiles: ['./jest.setup.js'],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,7 @@
+import 'react-native-gesture-handler/jestSetup';
+
+// Silence the warning: Animated: `useNativeDriver` is not supported.
+jest.mock('react-native/Libraries/Animated/NativeAnimatedHelper');
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);

--- a/src/screens/DeviceDataScreen.js
+++ b/src/screens/DeviceDataScreen.js
@@ -28,6 +28,7 @@ import Mailer from 'react-native-mail';
 import { NordicDFU, DFUEmitter } from 'react-native-nordic-dfu';
 import io from 'socket.io-client';
 import {backendLink} from '../api/api'
+import {firmwareFilePath} from '../utils/firmwareManager';
 
 
 
@@ -808,13 +809,11 @@ const DeviceDataScreen = () => {
   
   const proceedDFU = async (dfuTargetId) => {
     setDfuStatus('Starting DFU update...');
-    // Replace with the actual path to your DFU firmware package
-    console.log("Firmware path:", RNFS.MainBundlePath);
-    const firmwareFilePath = `file://${RNFS.MainBundlePath}/ppgv3.0.zip`;
+    const dfuPath = `file://${firmwareFilePath}`;
     try {
       const result = await NordicDFU.startDFU({
         deviceAddress: dfuTargetId,
-        filePath: firmwareFilePath,
+        filePath: dfuPath,
         // Optionally add a device name or other options if required:
         // name: "Your Device Name"
       });

--- a/src/utils/firmwareManager.js
+++ b/src/utils/firmwareManager.js
@@ -1,0 +1,19 @@
+import RNFS from 'react-native-fs';
+import {backendLink} from '../api/api';
+
+export const firmwareFileName = 'latest_firmware.zip';
+export const firmwareFilePath = `${RNFS.DocumentDirectoryPath}/${firmwareFileName}`;
+
+export const downloadLatestFirmware = async () => {
+  try {
+    const result = await RNFS.downloadFile({
+      fromUrl: `${backendLink}currentfirmware`,
+      toFile: firmwareFilePath,
+    }).promise;
+    console.log('Firmware download result:', result);
+    return firmwareFilePath;
+  } catch (error) {
+    console.error('Error downloading firmware:', error);
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary
- download firmware on startup
- share firmware path constant
- use downloaded firmware for DFU updates
- add jest configuration and mocks to help tests run

## Testing
- `yarn test` *(fails: Jest encountered unexpected token in react-redux esm)*