### PR TITLE
Update HomeScreen charts and feedback

### DIFF
--- a/src/components/CustomSVGComponent.js
+++ b/src/components/CustomSVGComponent.js
@@ -70,6 +70,7 @@ const HalfCircleSVGs = ({ selectedIndex = 26 }) => {
       </View>
 
       {/* Badge and subtitle in one row */}
+      {/**
       <View style={styles.badgeRow}>
         <View style={styles.badge}>
           <Text style={styles.badgeText}>5%</Text>
@@ -78,6 +79,7 @@ const HalfCircleSVGs = ({ selectedIndex = 26 }) => {
           of your sleep was{'\n'}compromised by bruxism
         </Text>
       </View>
+      */}
     </View>
   );
 };

--- a/src/components/GraphComponent.js
+++ b/src/components/GraphComponent.js
@@ -1,81 +1,45 @@
 import React from 'react';
-import {View, Dimensions, StyleSheet, SafeAreaView, Text} from 'react-native';
-import {LineChart} from 'react-native-chart-kit';
+import { View, Dimensions, StyleSheet, SafeAreaView } from 'react-native';
+import { LineChart, Grid, XAxis, YAxis } from 'react-native-svg-charts';
+import * as scale from 'd3-scale';
 
-const GraphComponent = props => {
-  const {data, labels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'], color} = props;
-
-  // react-native-chart-kit expects all data points to be numeric values. If the
-  // dataset contains `NaN` or non-numeric values, the library may attempt to
-  // call `.toFixed()` on them which results in the runtime error observed in
-  // `HomeScreen`.
-  //
-  // To avoid that, convert any invalid entries to `0` and ensure that the
-  // dataset always contains at least one value.
-  const sanitizedData = (data || []).map(d =>
-    typeof d === 'number' && !isNaN(d) ? d : 0,
-  );
+const GraphComponent = ({ data, labels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'], color = '#00BE2A' }) => {
+  const sanitizedData = (data || []).map(d => (typeof d === 'number' && !isNaN(d) ? d : 0));
   const finalData = sanitizedData.length > 0 ? sanitizedData : [0];
+  const contentInset = { top: 20, bottom: 20 };
+  const screenWidth = Dimensions.get('window').width - 32;
 
   return (
     <SafeAreaView style={styles.screen}>
-      <View style={styles.container}>
-        <LineChart
-          data={{
-            labels: labels,
-            datasets: [
-              {
-                data: finalData, // Sanitised dataset guaranteed to have numeric values
-                color: (opacity = 1) =>
-                  color || `rgba(39, 255, 233, ${opacity})`, // Overall color function with adjustable opacity
-                strokeWidth: 0.4, // Line thickness
-              },
-            ],
-          }}
-          width={Dimensions.get('window').width - 32}
-          height={250}
-          yAxisLabel=""
-          chartConfig={{
-            backgroundColor: '#232323',
-            backgroundGradientFrom: '#232323',
-            backgroundGradientTo: '#232323',
-            decimalPlaces: 2,
-            color: (opacity = 1) => `rgba(39, 255, 233, ${opacity})`,
-            labelColor: (opacity = 1) => `rgba(255, 255, 255, ${opacity})`,
-            style: {
-              borderRadius: 16,
-            },
-            propsForDots: {
-              r: '0', // No dots on the line
-            },
-            propsForBackgroundLines: {
-              strokeDasharray: '5',
-              strokeWidth: 1,
-              stroke: '#333',
-            },
-          }}
-          withDots={false}
-          withInnerLines={true}
-          withOuterLines={false}
-          withShadow={false}
-          withVerticalLines={false}
-          withHorizontalLines={true}
-          style={{
-            backgroundColor: 'transparent',
-          }}
-          bezier={true}
+      <View style={styles.row}>
+        <YAxis
+          data={finalData}
+          contentInset={contentInset}
+          svg={{ fill: 'rgba(255,255,255,0.7)', fontSize: 10 }}
+          numberOfTicks={5}
+          min={0}
+          max={100}
+          style={{ marginRight: 10 }}
         />
-         {/* {color === "#00BE2A" && (<Text style={styles.graphText}>
-         
-         You mostly had a <Text style={styles.lowText}>low</Text> Byte Score
-         this week. Your highest Byte Score was <Text style={styles.lowText}>65</Text>  on  <Text style={styles.lowText}>Friday.</Text>
-       </Text>)}
-         {color === "#FF8B02" && (<Text style={styles.graphText}>
-         
-          You had a <Text style={styles.lowText}>High</Text> number of bruxism episodes this week. Your highest number of episodes was <Text style={styles.lowText}>7</Text> on <Text style={styles.lowText}>Friday</Text>
-       </Text>)} */}
-        
+        <LineChart
+          style={{ height: 250, width: screenWidth - 20 }}
+          data={finalData}
+          svg={{ stroke: color, strokeWidth: 2 }}
+          contentInset={contentInset}
+          yMin={0}
+          yMax={100}
+        >
+          <Grid svg={{ stroke: '#333', strokeDasharray: '5', strokeWidth: 1 }} />
+        </LineChart>
       </View>
+      <XAxis
+        style={{ marginHorizontal: 16, height: 20 }}
+        data={finalData}
+        formatLabel={(value, index) => labels[index]}
+        contentInset={{ left: 20, right: 20 }}
+        svg={{ fontSize: 10, fill: 'white' }}
+        scale={scale.scaleBand}
+      />
     </SafeAreaView>
   );
 };
@@ -85,23 +49,9 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: 'transparent',
   },
-  container: {
+  row: {
+    flexDirection: 'row',
     marginHorizontal: 16,
-    backgroundColor: 'transparent',
-  },
-  graphText: {
-    color: 'rgba(255, 255, 255, 0.50)',
-    fontSize: 12,
-    fontWeight: '400',
-    marginHorizontal: 18,
-    marginTop: 14,
-    lineHeight: 18,
-  },
-  lowText: {
-    color: 'rgba(255, 255, 255, 0.50)',
-    fontSize: 12,
-    fontWeight: '700',
-    lineHight: 18,
   },
 });
 

--- a/src/screens/HomeScreen.js
+++ b/src/screens/HomeScreen.js
@@ -239,7 +239,7 @@ const SplashScreen = () => {
     return score > threshold ? ['#0f3d3e', '#232323'] : ['#411E1F', '#232323'];
   };
 
-  const getRangeGraphData = () => {
+  const getRangeGraphData = (field = 'byteScore') => {
     const days = [];
     for (let m = rangeStart.clone(); m.isSameOrBefore(rangeEnd); m.add(1, 'day')) {
       days.push(m.clone());
@@ -249,13 +249,16 @@ const SplashScreen = () => {
     );
     const data = days.map(d => {
       const found = healthData.find(h => moment(h.Date).isSame(d, 'day'));
-      const val = found ? toNumber(found.byteScore) : NaN;
+      const val = found ? toNumber(found[field]) : NaN;
       return val;
     });
     return { labels, data };
   };
 
-  const { labels: graphLabels, data: dailyByteScoreData } = getRangeGraphData();
+  const { labels: graphLabels, data: dailyByteScoreData } = getRangeGraphData('byteScore');
+  const { data: recoveryScoreData } = getRangeGraphData('recoveryScore');
+  const { data: stressLoadScoreData } = getRangeGraphData('stressLoadScore');
+  const { data: recoveryTrendScoreData } = getRangeGraphData('recoveryTrendScore');
 
   const changeMonth = offset => {
     setCalendarViewDate(prev => prev.clone().add(offset, 'month'));
@@ -319,6 +322,7 @@ const SplashScreen = () => {
               setSelectedDateIndex={handleDateChange}
             />
           </View>
+          {/**
           <View style={styles.statsSection}>
             <View style={styles.heartImageView}>
               <Image source={redTimer} style={[styles.heartImage, { alignSelf: "flex-start" }]} />
@@ -339,6 +343,7 @@ const SplashScreen = () => {
               </View>
             </View>
           </View>
+          */}
           <View style={styles.container2}>
             <HalfCircleSVGs selectedIndex={score} />
           </View>
@@ -372,6 +377,7 @@ const SplashScreen = () => {
             </View>
           </View>
         </LinearGradient> */}
+        {score !== '--' && (
         <LinearGradient
           colors={[byteScoreFeedback.color, byteScoreFeedback.color]}
           start={{ x: 0, y: 0 }}
@@ -399,18 +405,16 @@ const SplashScreen = () => {
               </View>
 
               <Text
-                numberOfLines={2}
                 style={{
                   width: "95%",
-                  color: "#A8A9AA",
+                  color: "#fff",
                   fontSize: 14,
-                  textAlign: "justify",
                   paddingLeft: 20,
                   fontFamily: "Ubuntu",
-                  fontWeight: 400,
-                  paddingBottom: 20,
+                  fontWeight: "400",
+                  lineHeight: 20,
                   marginTop: 5,
-                  lineHeight: 24,
+                  marginBottom: 10,
                 }}
               >
                 {byteScoreFeedback.description}
@@ -418,6 +422,7 @@ const SplashScreen = () => {
             </View>
           </View>
         </LinearGradient>
+        )}
 
 
         {/* <LinearGradient  // Your Action Focus hidden
@@ -566,6 +571,15 @@ const SplashScreen = () => {
 
         <Text style={styles.sectionTitle}>Daily Byte Score</Text>
         <GraphComponent data={dailyByteScoreData} labels={graphLabels} color="#00BE2A" />
+
+        <Text style={styles.sectionTitle}>Daily Morning Readiness</Text>
+        <GraphComponent data={recoveryScoreData} labels={graphLabels} color="#00BE2A" />
+
+        <Text style={styles.sectionTitle}>Daily Relaxation Index</Text>
+        <GraphComponent data={stressLoadScoreData} labels={graphLabels} color="#00BE2A" />
+
+        <Text style={styles.sectionTitle}>Stress Relief Score</Text>
+        <GraphComponent data={recoveryTrendScoreData} labels={graphLabels} color="#00BE2A" />
 
         {/* <Text style={styles.sectionTitle}>Bruxism</Text> */}
 


### PR DESCRIPTION
## Summary
- hide bruxism stats and compromised-sleep text
- tweak byte score feedback box
- add new graphs for readiness, relaxation, and relief
- force chart y-axis to 0-100 with updated component

## Testing
- `yarn lint` *(fails: Cannot find module 'typescript')*
- `yarn test` *(fails: Jest encountered an unexpected token)*