### PR TITLE
Fix unmatched brace in DeviceDataScreen

### DIFF
--- a/src/screens/DeviceDataScreen.js
+++ b/src/screens/DeviceDataScreen.js
@@ -875,7 +875,7 @@ const DeviceDataScreen = () => {
                   <Text style={styles.buttonText}>Disconnect</Text>
                 </TouchableOpacity>
               </View>
-            )
+            )}
             <View style={styles.deviceInfoContainerImage}>
               <View style={styles.imageBackground}>
                 <Image source={teethLogo} style={styles.teethlogo} />


### PR DESCRIPTION
## Summary
- fix missing closing brace for the optionsVisible conditional rendering

## Testing
- `yarn test` *(fails: SyntaxError from jest config)*