### PR TITLE
Fix icon font and remove splash label

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,9 +1,10 @@
 <resources>
 
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="android:textColor">#000000</item>
+        <item name="android:windowBackground">@android:color/black</item>
     </style>
 
 </resources>

--- a/ios/BruxAway/Info.plist
+++ b/ios/BruxAway/Info.plist
@@ -91,8 +91,9 @@
 		<string>Ubuntu-Light.ttf</string>
 		<string>Ubuntu-LightItalic.ttf</string>
 		<string>Ubuntu-Medium.ttf</string>
-		<string>Ubuntu-MediumItalic.ttf</string>
-		<string>Ubuntu-Regular.ttf</string>
-	</array>
+<string>Ubuntu-MediumItalic.ttf</string>
+<string>Ubuntu-Regular.ttf</string>
+<string>Feather.ttf</string>
+</array>
 </dict>
 </plist>

--- a/ios/BruxAway/LaunchScreen.storyboard
+++ b/ios/BruxAway/LaunchScreen.storyboard
@@ -17,18 +17,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" text="BruxAway" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
-                                <rect key="frame" x="0.0" y="312" width="375" height="43"/>
-                                <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <color key="backgroundColor" red="0" green="0" blue="0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="GJd-Yh-RWb" secondAttribute="centerX" id="Q3B-4B-g5h"/>
-                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="bottom" multiplier="1/3" constant="1" id="moa-c2-u7t"/>
-                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" symbolic="YES" id="x7j-FC-K8j"/>
                         </constraints>
                     </view>
                 </viewController>

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,8 +1,8 @@
 module.exports = {
-  assets: ['./src/assets/fonts'],
+  assets: ['./src/assets/fonts', './node_modules/react-native-vector-icons/Fonts'],
   project: {
     android: {
-      packageName: "com.bruxaway",
+      packageName: 'com.bruxaway',
     },
   },
 };


### PR DESCRIPTION
## Summary
- ensure vector icon fonts are bundled
- darken default Android launch background
- remove the text from iOS launch screen and make it black
- add Feather font to Info.plist

## Testing
- `yarn test` *(fails: SyntaxError in react-redux)*