### PR TITLE
Fix BleManager import

### DIFF
--- a/src/utils/bleManager.js
+++ b/src/utils/bleManager.js
@@ -1,4 +1,5 @@
 import BleManager from 'react-native-ble-manager';
 
-// Export a single shared instance of BleManager
-export default new BleManager();
+// `react-native-ble-manager` already exports a singleton instance. Re-export that
+// instance so the rest of the app can import it from one place.
+export default BleManager;


### PR DESCRIPTION
## Summary
- use the singleton instance exported by `react-native-ble-manager`

## Testing
- `yarn test` *(fails: SyntaxError: Cannot use import statement outside a module)*