### PR TITLE
Avoid restarting BLE manager when scanning

### DIFF
--- a/src/screens/BluetoothScanner.js
+++ b/src/screens/BluetoothScanner.js
@@ -37,10 +37,8 @@ const BluetoothScanner = () => {
     // Request permissions
     requestPermissions();
 
-    // Start BleManager
-    bleManager.start({ showAlert: false }).then(() => {
-      console.log('Bluetooth module initialized');
-    });
+    // The BLE manager is started once when the app launches (see App.js).
+    // Avoid reinitializing it here and proceed directly with scanning.
 
     // Add listener for discovered peripherals
     const discoverListener = bleManagerEmitter.addListener('BleManagerDiscoverPeripheral', (peripheral) => {

--- a/src/screens/DevicesFound.js
+++ b/src/screens/DevicesFound.js
@@ -69,10 +69,9 @@ const DevicesFoundScreen = () => {
   useEffect(() => {
     requestPermissions();
 
-    bleManager.start({showAlert: false}).then(() => {
-      console.log('Bluetooth module initialized');
-      setBleInitialized(true);
-    });
+    // BLE manager is started once in App.js. Simply mark it as
+    // initialized so scanning can begin when permissions are granted.
+    setBleInitialized(true);
 
     const discoverListener = bleManagerEmitter.addListener(
       'BleManagerDiscoverPeripheral',


### PR DESCRIPTION
## Summary
- start BLE manager once in `App.js`
- remove duplicate `start` calls from scanning screens

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*