### PR TITLE
Switch biometric data send to HTTP endpoint

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -117,4 +117,13 @@ export const fetchPatientData = async () => {
     throw new Error(handleApiError(error));
   }
 };
+
+export const postBiometricData = async (payload) => {
+  try {
+    const response = await api.post('/biometricData', payload);
+    return response.data;
+  } catch (error) {
+    throw new Error(handleApiError(error));
+  }
+};
 export default api;


### PR DESCRIPTION
## Summary
- remove socket-based biometric data transmission
- add HTTP API helper `postBiometricData`
- update `DeviceDataScreen` to post biometric data via endpoint

## Testing
- `yarn test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_683a2ed31158832a9a95cdca1d180086