### PR TITLE
Update device reconnect navigation

### DIFF
--- a/src/screens/DeviceDataScreen.js
+++ b/src/screens/DeviceDataScreen.js
@@ -308,6 +308,7 @@ const disconnectDevice = async () => {
       await bleManager.disconnect(deviceRef.current.id);
       setIsConnected(false);
       console.log('Device disconnected');
+      await AsyncStorage.removeItem('selectedDevice');
     } catch (error) {
       console.error('Error disconnecting:', error);
     }
@@ -898,7 +899,10 @@ const disconnectDevice = async () => {
           start={{x: 0, y: 0}}
           end={{x: 0.8, y: 1}}
           style={styles.LinearView}>
-          <Header title="byteGuard" />
+          <Header
+            title="byteGuard"
+            onBack={() => navigation.navigate('ProfileScreen')}
+          />
           <LinearGradient
             colors={['rgba(255, 255, 255, 0.04)', 'rgba(255, 255, 255, 0.02)']}
             start={{x: 0, y: 0}}

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {
   View,
   Text,
@@ -27,6 +27,20 @@ const ProfileScreen = () => {
   const navigation = useNavigation(); // Initialize navigation using the hook
 
   const [isDarkMode, setIsDarkMode] = useState(false);
+  const [deviceConnected, setDeviceConnected] = useState(false);
+
+  useEffect(() => {
+    const unsubscribe = navigation.addListener('focus', async () => {
+      try {
+        const dev = await AsyncStorage.getItem('selectedDevice');
+        setDeviceConnected(!!dev);
+      } catch (e) {
+        console.error('Error reading device info', e);
+        setDeviceConnected(false);
+      }
+    });
+    return unsubscribe;
+  }, [navigation]);
 
   const toggleSwitch = () => setIsDarkMode(previousState => !previousState);
 
@@ -46,6 +60,20 @@ const ProfileScreen = () => {
         },
       },
     ]);
+  };
+
+  const handleDevicesPress = async () => {
+    try {
+      const dev = await AsyncStorage.getItem('selectedDevice');
+      if (dev) {
+        navigation.navigate('DeviceDataScreen');
+      } else {
+        navigation.navigate('ScanningForDeviceScreen');
+      }
+    } catch (e) {
+      console.error('Error reading device info', e);
+      navigation.navigate('ScanningForDeviceScreen');
+    }
   };
 
   const renderOption = (icon, title, subtitle, onPress, isSwitch) => (
@@ -89,10 +117,8 @@ const ProfileScreen = () => {
         {renderOption(
           devicesIcon,
           'Devices',
-          '0 Device Connected',
-          () => {
-            navigation.navigate('ScanningForDeviceScreen');
-          },
+          deviceConnected ? '1 Device Connected' : '0 Device Connected',
+          handleDevicesPress,
           false,
         )}
         {renderOption(

--- a/src/screens/header.js
+++ b/src/screens/header.js
@@ -6,18 +6,20 @@ import backArrow from '../assets/backArrow.png'; // Back arrow image
 
 const { width } = Dimensions.get('window'); // Get screen width
 
-const Header = ({ title = "Sleep Report", showBackArrow = true }) => {
+const Header = ({ title = "Sleep Report", showBackArrow = true, onBack }) => {
   const navigation = useNavigation(); // For handling navigation
 
   return (
     <View style={styles.headerContainer}>
       {/* Back Arrow */}
       {showBackArrow ? (
-        <TouchableOpacity onPress={() => navigation.goBack('')} style={styles.backArrowContainer}>
+        <TouchableOpacity
+          onPress={onBack ? onBack : () => navigation.goBack('')}
+          style={styles.backArrowContainer}>
           <Image source={backArrow} style={styles.backArrow} />
         </TouchableOpacity>
       ) : (
-        <View style={styles.backArrowContainer} />  // Empty view for spacing
+        <View style={styles.backArrowContainer} /> // Empty view for spacing
       )}
 
       {/* Title, centered */}


### PR DESCRIPTION
## Summary
- add optional onBack handler for `Header`
- remove device info from storage when disconnecting
- update device screen header back navigation
- adjust device button in profile to open device data when already connected

## Testing
- `yarn test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `yarn lint` *(fails: Failed to load parser '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_b_683a3861930c832ab7ca18ce0ac2d3ad