### PR TITLE
Improve sleep insights display

### DIFF
--- a/src/components/SleepScoreBars.js
+++ b/src/components/SleepScoreBars.js
@@ -14,7 +14,8 @@ const SleepScoreBarChart = ({ data = [], selectedIndex = 0, onSelect }) => {
   useEffect(() => {
     if (scrollRef.current && data.length > 0) {
       const contentWidth = data.length * (BAR_WIDTH + GAP);
-      const offset = (selectedIndex + 1) * (BAR_WIDTH + GAP) - screenWidth;
+      const offset =
+        selectedIndex * (BAR_WIDTH + GAP) - (screenWidth - BAR_WIDTH) / 2;
       const minOffset = 0;
       const maxOffset = Math.max(0, contentWidth - screenWidth);
       const clampedOffset = Math.max(minOffset, Math.min(maxOffset, offset));

--- a/src/screens/SleepInsightsScreen.js
+++ b/src/screens/SleepInsightsScreen.js
@@ -83,6 +83,24 @@ const SleepInsightsPage = ({ route, navigation }) => {
     });
   }, [selectedData]);
 
+  useEffect(() => {
+    if (selectedData) {
+      console.log('Selected day scores', {
+        date: selectedData.Date,
+        byteScore: Math.round(toNumber(selectedData.byteScore) || 0),
+        recoveryDepthScore: Math.round(
+          toNumber(selectedData.recoveryDepthScore) || 0,
+        ),
+        stressReliefScore: Math.round(
+          toNumber(selectedData.recoveryTrendScore) || 0,
+        ),
+        relaxationScore: Math.round(
+          toNumber(selectedData.stressLoadScore) || 0,
+        ),
+      });
+    }
+  }, [selectedData]);
+
   const totalSleepMinutes = useMemo(() => {
     if (!selectedData?.activities) return 0;
     return selectedData.activities
@@ -90,9 +108,10 @@ const SleepInsightsPage = ({ route, navigation }) => {
       .reduce((sum, a) => sum + (a.duration || 0), 0);
   }, [selectedData]);
 
-  const hours = Math.floor(totalSleepMinutes / 60);
-  const mins = totalSleepMinutes % 60;
-  const timeInBed = totalSleepMinutes ? `${hours}h${mins}m` : '--';
+  const roundedSleepMinutes = Math.round(totalSleepMinutes);
+  const hours = Math.floor(roundedSleepMinutes / 60);
+  const mins = roundedSleepMinutes % 60;
+  const timeInBed = roundedSleepMinutes ? `${hours}h${mins}m` : '--';
 
   const title = moment(selectedData?.Date || date).format('ddd, MMM DD');
 


### PR DESCRIPTION
## Summary
- keep selected bar centered when screen opens
- round time in bed to the nearest minute
- log scores for the selected day

## Testing
- `yarn test` *(fails: SyntaxError in Jest setup)*

------
https://chatgpt.com/codex/tasks/task_b_683a3a1696ac832abeba3a172e29972f