### PR TITLE
Fix SleepInsights bar selection height

### DIFF
--- a/src/components/SleepScoreBars.js
+++ b/src/components/SleepScoreBars.js
@@ -42,10 +42,7 @@ const SleepScoreBarChart = ({ data = [], selectedIndex = 0, onSelect }) => {
               <View
                 style={[
                   isSelected ? styles.selectedBarWrapper : styles.barWrapper,
-                  isSelected && {
-                    height: MAX_BAR_HEIGHT,
-                  },
-                  { height: isSelected ? MAX_BAR_HEIGHT : barHeight },
+                  { height: barHeight },
                 ]}
               >
                 <View style={{ height: 28, justifyContent: 'center', alignItems: 'center', zIndex: 2 }}>


### PR DESCRIPTION
## Summary
- ensure selected bars keep original height in Sleep Score chart

## Testing
- `yarn test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_683a3d940f28832ab9ed3408d0e24033