### PR TITLE
Fix initial scroll to selected bar on SleepInsights

### DIFF
--- a/src/components/SleepScoreBars.js
+++ b/src/components/SleepScoreBars.js
@@ -9,17 +9,28 @@ const GAP = 10;
 
 const SleepScoreBarChart = ({ data = [], selectedIndex = 0, onSelect }) => {
   const scrollRef = useRef(null);
+  const hasInitialScroll = useRef(false);
   const screenWidth = Dimensions.get('window').width;
+
+  const calculateOffset = () => {
+    const contentWidth = data.length * (BAR_WIDTH + GAP);
+    const offset =
+      selectedIndex * (BAR_WIDTH + GAP) - (screenWidth - BAR_WIDTH) / 2;
+    const minOffset = 0;
+    const maxOffset = Math.max(0, contentWidth - screenWidth);
+    return Math.max(minOffset, Math.min(maxOffset, offset));
+  };
 
   useEffect(() => {
     if (scrollRef.current && data.length > 0) {
-      const contentWidth = data.length * (BAR_WIDTH + GAP);
-      const offset =
-        selectedIndex * (BAR_WIDTH + GAP) - (screenWidth - BAR_WIDTH) / 2;
-      const minOffset = 0;
-      const maxOffset = Math.max(0, contentWidth - screenWidth);
-      const clampedOffset = Math.max(minOffset, Math.min(maxOffset, offset));
-      scrollRef.current.scrollTo({ x: clampedOffset, animated: true });
+      const clampedOffset = calculateOffset();
+      scrollRef.current.scrollTo({
+        x: clampedOffset,
+        animated: hasInitialScroll.current,
+      });
+      if (!hasInitialScroll.current) {
+        hasInitialScroll.current = true;
+      }
     }
   }, [selectedIndex, data.length, screenWidth]);
 


### PR DESCRIPTION
## Summary
- ensure the Sleep Score graph scrolls to the selected day on first render

## Testing
- `yarn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a3f6240e4832ab1b1ab6d40e01d69