### PR TITLE
Fix ATS domain entry for iOS

### DIFF
--- a/ios/BruxAway/Info.plist
+++ b/ios/BruxAway/Info.plist
@@ -41,7 +41,7 @@
 				<key>NSTemporaryExceptionMinimumTLSVersion</key>
 				<string>TLSv1.0</string>
 			</dict>
-			<key>New Exception Domain</key>
+                        <key>api.bytesense.ai</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>


### PR DESCRIPTION
## Summary
- update Info.plist to include `api.bytesense.ai` in `NSExceptionDomains`

## Testing
- `yarn test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_683d328233ec832aad3e6e7e8937e943