### PR TITLE
Fix settings.gradle for React Native 0.75

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,6 +1,17 @@
-pluginManagement { includeBuild("../node_modules/@react-native/gradle-plugin") }
-plugins { id("com.facebook.react.settings") }
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+    includeBuild('../node_modules/@react-native/gradle-plugin')
+    plugins {
+        id 'com.facebook.react.settings' version '0.75.0' apply false
+    }
+}
+plugins {
+    id 'com.facebook.react.settings'
+}
 extensions.configure(com.facebook.react.ReactSettingsExtension){ ex -> ex.autolinkLibrariesFromCommand() }
 rootProject.name = 'BruxAway'
 include ':app'
-includeBuild('../node_modules/@react-native/gradle-plugin')


### PR DESCRIPTION
## Summary
- configure Android `settings.gradle` for React Native 0.75 plugin

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_b_6850d21566c0832aa87a31e7199115e0