### PR TITLE
Update Android build config for RN 0.75

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,21 +1,28 @@
 buildscript {
-    ext {
-        buildToolsVersion = "34.0.0"
-        minSdkVersion = 23
-        compileSdkVersion = 34
-        targetSdkVersion = 34
-        ndkVersion = "26.1.10909125"
-        kotlinVersion = "1.9.24"
-    }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle")
+        classpath("com.android.tools.build:gradle:8.4.0")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24")
     }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+ext {
+    buildToolsVersion = "34.0.0"
+    minSdkVersion = 24
+    compileSdkVersion = 34
+    targetSdkVersion = 34
+    ndkVersion = "25.1.8937393"
 }
 
 apply plugin: "com.facebook.react.rootproject"


### PR DESCRIPTION
## Summary
- update root `build.gradle` for Gradle 8.8 and React Native 0.75
- keep settings.gradle React plugin setup

## Testing
- `./gradlew assembleRelease` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_b_6850da96df80832a8a84e60971cf8dee